### PR TITLE
Fix spawning with pistol ammo

### DIFF
--- a/lua/weapons/darkrpg2_swep/shared.lua
+++ b/lua/weapons/darkrpg2_swep/shared.lua
@@ -34,6 +34,13 @@ SWEP.Primary.DefaultClip = -1
 SWEP.Primary.Automatic = false
 SWEP.Primary.Ammo = ""
 
+SWEP.Secondary.Damage	= -1
+SWEP.Secondary.Delay 	= -1
+SWEP.Secondary.ClipSize = -1
+SWEP.Secondary.DefaultClip = -1
+SWEP.Secondary.Automatic = false
+SWEP.Secondary.Ammo = ""
+
 SWEP.ViewModelFOV = 62
 SWEP.ViewModelFlip = false
 SWEP.UseHands = true


### PR DESCRIPTION
upon receiving the darkrpg swep, players would receive pistol ammo:
darkrpg swep didnt previously replace secondary ammo, which lead to default secondary, being pistol ammo, 8 clip and 32 reserve, which would give players 24 pistol ammo on spawn.